### PR TITLE
Re-arrange order of users in "user" fields.

### DIFF
--- a/labhamster/admin.py
+++ b/labhamster/admin.py
@@ -213,7 +213,7 @@ class OrderAdmin(RequestFormAdmin):
     radio_fields = {'grant': admin.VERTICAL,
                     'grant_category': admin.VERTICAL}
 
-    list_display = ('show_title',  'Status', 'show_urgent',
+    list_display = ('show_title', 'Status', 'show_urgent',
                     'show_quantity', 'show_price',
                     'requested', 'show_requestedby', 'ordered',
                     'received', 'show_comment',)

--- a/labhamster/customforms.py
+++ b/labhamster/customforms.py
@@ -28,8 +28,8 @@ class OrderForm(forms.ModelForm):
         users = User.objects.order_by(
             Case(When(id=self.request.user.id, then=0), default=1), 'username')
 
-        self.fields['created_by'] = forms.ModelChoiceField(users)
-        self.fields['ordered_by'] = forms.ModelChoiceField(users)
+        self.fields['created_by'].queryset = users
+        self.fields['ordered_by'].queryset = users
 
     class Meta:
         model = M.Order

--- a/labhamster/customforms.py
+++ b/labhamster/customforms.py
@@ -4,6 +4,8 @@
 # LabHamster is released under the MIT open source license, which you can find
 # along with this project (LICENSE) or at <https://opensource.org/licenses/MIT>.
 import django.forms as forms
+from django.db.models import Case, When
+from django.contrib.auth.models import User
 import labhamster.models as M
 
 
@@ -22,6 +24,12 @@ class OrderForm(forms.ModelForm):
             # stopped working in django 1.9:
             ## self.initial['created_by'] = str(self.request.user.id)
             self.fields['created_by'].initial = self.request.user.id
+
+        users = User.objects.order_by(
+            Case(When(id=self.request.user.id, then=0), default=1), 'username')
+
+        self.fields['created_by'] = forms.ModelChoiceField(users)
+        self.fields['ordered_by'] = forms.ModelChoiceField(users)
 
     class Meta:
         model = M.Order


### PR DESCRIPTION
Sort users by alphabetical order, with the exception of the current user being at the top of the list in "Created by" and "Ordered by" fields of the Order administration.

Close #7